### PR TITLE
Spotify' object has no attribute 'playlist'

### DIFF
--- a/custom_components/spotify-playlist-sensor/manifest.json
+++ b/custom_components/spotify-playlist-sensor/manifest.json
@@ -3,6 +3,6 @@
   "name": "Spotify Playlist Sensor",
   "documentation": "https://github.com/dnguyen800/spotify-playlist-sensor",
   "dependencies": ["http"],
-  "requirements": ["spotipy-homeassistant==2.4.4.dev1"], 
+  "requirements": ["spotipy==2.7.1"], 
   "codeowners": ["@dnguyen800"]
 }

--- a/custom_components/spotify-playlist-sensor/sensor.py
+++ b/custom_components/spotify-playlist-sensor/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import callback
 
 DEPENDENCIES = ['http']
-REQUIREMENTS = ['spotipy-homeassistant==2.4.4.dev1']
+REQUIREMENTS = ['spotipy==2.7.1']
 
 __version__ = '0.0.2'
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
fixes : https://github.com/dnguyen800/spotify-playlist-sensor/issues/6#